### PR TITLE
Add more datadog methods

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.2.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov/
 build/
 dist/
 .idea/
+venv/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+pytest==2.9.2
+mock==2.0.0
+bumpversion==0.5.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,0 @@
-pytest==2.9.2
-mock==2.0.0
-bumpversion==0.5.3

--- a/panopticon/__init__.py
+++ b/panopticon/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 
 
 class PanopticonSettings(dict):

--- a/panopticon/datadog.py
+++ b/panopticon/datadog.py
@@ -194,8 +194,12 @@ class DataDog(object):
         """
         Convert tags, which may be a dict or iterable, into
         the DataDog format of a list of 'key:value' strings.
-        :param tags: dict or iterable
-        :return: list
+
+        Args:
+            tags (Dict, Sequence):
+
+        Returns:
+            [str]
         """
         if isinstance(tags, dict):
             return [
@@ -211,11 +215,10 @@ class DataDog(object):
         Record a gauge value (for a gauge, the latest value within any one
         minute is the value stored).
 
-        :param metric_name: name of the value metric to be stored
-        :type metric_name: string
-        :param value: integer value
-        :param tags: miscellaneous tags to further describe the value
-        :type tags: dict or list
+        Args:
+            metric_name (str): name of the metric to be stored
+            value (int or float): the value of the metric
+            tags (list or dict): miscellaneous tags to describe the value
         """
         cls.stats().gauge(
             cls.get_metric_name(metric_name),
@@ -230,11 +233,10 @@ class DataDog(object):
         Increment a metric_name value (all the increments and decrements within
         a given minute are summed together).
 
-        :param metric_name: name of the value metric to be incremented
-        :type metric_name: string
-        :param value: value by which to increment the metric (default is 1)
-        :param tags: miscellaneous tags to further describe the value
-        :type tags: dict or list
+        Args:
+            metric_name (str): name of the metric to be incremented
+            value (int or float): how much to increment the metric value
+            tags (list or dict): miscellaneous tags to describe the value
         """
         cls.stats().increment(
             cls.get_metric_name(metric_name),
@@ -249,11 +251,10 @@ class DataDog(object):
         Decrement a metric_name value (all the increments and decrements within
         a given minute are summed together).
 
-        :param metric_name: name of the value metric to be decremented
-        :type metric_name: string
-        :param value: value by which to decrement the metric (default is 1)
-        :param tags: miscellaneous tags to further describe the value
-        :type tags: dict or list
+        Args:
+            metric_name (str): name of the metric to be decremented
+            value (int or float): how much to decrement the metric value
+            tags (list or dict): miscellaneous tags to describe the value
         """
         cls.stats().decrement(
             cls.get_metric_name(metric_name),
@@ -269,10 +270,10 @@ class DataDog(object):
         of the recorded values of a metric (minimum, maximum, average, count
         and the 75th, 85th, 95th and 99th percentiles).
 
-        :param metric_name: name of the metric
-        :param value: value to be recorded
-        :param tags: miscellaneous tags to further describe the value
-        :type tags: dict or list
+        Args:
+            metric_name (str): name of the metric to be stored
+            value (int or float): the value of the metric
+            tags (list or dict): miscellaneous tags to describe the value
         """
         cls.stats().histogram(
             cls.get_metric_name(metric_name),
@@ -289,9 +290,11 @@ class DataDog(object):
         Note that an event title is not a metric name, so no
         DATADOG_STATS_PREFIX value is prepended to it.
 
-        :param title: Event title (string)
-        :param text: Optional event text (string), support MarkDown (see
-            http://docs.datadoghq.com/guides/markdown/ )
+        Args:
+            title (str): Event title
+            text (str or None): Optional event text (string), supports
+                MarkDown (see http://docs.datadoghq.com/guides/markdown/ )
+            tags (list or dict): miscellaneous tags to describe the value
         """
         cls.stats().event(
             title,

--- a/panopticon/datadog.py
+++ b/panopticon/datadog.py
@@ -11,6 +11,48 @@ from . import PanopticonSettings
 
 
 class DataDog(object):
+    """
+    Abstraction over the DataDog python client.
+
+    Key methods are 'gauge', 'increment', 'decrement',
+    'histogram', and 'timing'. These can all be called
+    on the `DataDog` class to send metrics to DataDog.
+
+    We recommend that metric names should generally follow a
+    dot-hierarchy. For example, in a service called 'awesome', there might
+    be metrics called 'awesome.web_requests' or 'awesome.worker.tasks'.
+    Using a hierarchy makes it simpler to combine metrics from several
+    services in a single DataDog dashboard.
+
+    If the 'DATADOG_STATS_PREFIX' environment variable is defined, then
+    its value will be prepended to all metric names, followed by a '.'.
+
+    From the DataDog website:
+        There are a few rules to stick to when naming metrics:
+        * Metric names must start with a letter
+        * Can only contain ascii alphanumerics, underscore and periods
+          (other characters will get converted to underscores)
+        * Should not exceed 200 characters (though less than 100 is generally
+          preferred from a UI perspective)
+        * Unicode is not supported
+        * We recommend avoiding spaces
+
+    Metric values may be integers or floating point values.
+
+    Along with a metric value, DataDog accepts an arbitrary set of
+    key:value *tags*. The keys should be strings, the values should
+    generally also be strings. You can use tag values to split and combine
+    metrics when generating graphs or alerts in DataDog. The DataDog
+    python API accepts tags as lists of 'key:value' strings, and this
+    API will also accept them as dicts.
+
+    The 'event' method sends events to DataDog. Event names can be any
+    string, but we also recommend using a dot-hierarchy for them.
+
+    See http://docs.datadoghq.com/guides/metrics/ for more information
+    about how DataDog collects different types of metrics.
+
+    """
     KEY_DATADOG_API_KEY = 'DATADOG_API_KEY'
     KEY_DATADOG_ENABLED = 'DATADOG_STATS_ENABLED'
     KEY_DATADOG_STATS_PREFIX = 'DATADOG_STATS_PREFIX'
@@ -57,6 +99,8 @@ class DataDog(object):
         This will return a `mock.Mock` instance if the `DATADOG_ENABLED` setting
         is `False`. This makes it possible to run this in development without
         having to make any additional changes or conditional checks.
+
+        :return datadog.ThreadState
         """
         if cls._stats_instance:
             return cls._stats_instance
@@ -81,7 +125,9 @@ class DataDog(object):
     @classmethod
     def get_metric_name(cls, *args):
         """
-        Get the metric name prefixed with the name in `DATADOG_STATS_PREFIX`.
+        Get the metric name prefixed with the name in `DATADOG_STATS_PREFIX`,
+        given a list of metric name components as args, or a single metric
+        name.
         """
         return '.'.join((cls.STATS_PREFIX,) + args)
 
@@ -143,5 +189,115 @@ class DataDog(object):
 
         return track_time_decorator
 
+    @staticmethod
+    def _convert_tags(tags):
+        """
+        Convert tags, which may be a dict or iterable, into
+        the DataDog format of a list of 'key:value' strings.
+        :param tags: dict or iterable
+        :return: list
+        """
+        if isinstance(tags, dict):
+            return [
+                '{}:{}'.format(key, value)
+                for key, value in tags.items()
+            ]
+
+        return list(tags)
+
+    @classmethod
+    def gauge(cls, metric_name, value, tags=None, **kwargs):
+        """
+        Record a gauge value (for a gauge, the latest value within any one
+        minute is the value stored).
+
+        :param metric_name: name of the value metric to be stored
+        :type metric_name: string
+        :param value: integer value
+        :param tags: miscellaneous tags to further describe the value
+        :type tags: dict or list
+        """
+        cls.stats().gauge(
+            cls.get_metric_name(metric_name),
+            value=value,
+            tags=cls._convert_tags(tags),
+            **kwargs
+        )
+
+    @classmethod
+    def increment(cls, metric_name, value=1, tags=None, **kwargs):
+        """
+        Increment a metric_name value (all the increments and decrements within
+        a given minute are summed together).
+
+        :param metric_name: name of the value metric to be incremented
+        :type metric_name: string
+        :param value: value by which to increment the metric (default is 1)
+        :param tags: miscellaneous tags to further describe the value
+        :type tags: dict or list
+        """
+        cls.stats().increment(
+            cls.get_metric_name(metric_name),
+            value=value,
+            tags=cls._convert_tags(tags),
+            **kwargs
+        )
+
+    @classmethod
+    def decrement(cls, metric_name, value=1, tags=None, **kwargs):
+        """
+        Decrement a metric_name value (all the increments and decrements within
+        a given minute are summed together).
+
+        :param metric_name: name of the value metric to be decremented
+        :type metric_name: string
+        :param value: value by which to decrement the metric (default is 1)
+        :param tags: miscellaneous tags to further describe the value
+        :type tags: dict or list
+        """
+        cls.stats().decrement(
+            cls.get_metric_name(metric_name),
+            value=value,
+            tags=cls._convert_tags(tags),
+            **kwargs
+        )
+
+    @classmethod
+    def histogram(cls, metric_name, value, tags=None, **kwargs):
+        """
+        Send a histogram metric value. Histograms describe the distribution
+        of the recorded values of a metric (minimum, maximum, average, count
+        and the 75th, 85th, 95th and 99th percentiles).
+
+        :param metric_name: name of the metric
+        :param value: value to be recorded
+        :param tags: miscellaneous tags to further describe the value
+        :type tags: dict or list
+        """
+        cls.stats().histogram(
+            cls.get_metric_name(metric_name),
+            value=value,
+            tags=cls._convert_tags(tags),
+            **kwargs
+        )
+
+    @classmethod
+    def event(cls, title, text, tags=None, **kwargs):
+        """
+        Record a timing metric.
+
+        Note that an event title is not a metric name, so no
+        DATADOG_STATS_PREFIX value is prepended to it.
+
+        :param title: Event title (string)
+        :param text: Optional event text (string), support MarkDown (see
+            http://docs.datadoghq.com/guides/markdown/ )
+        """
+        cls.stats().event(
+            title,
+            text,
+            tags=cls._convert_tags(tags),
+            **kwargs
+        )
 
 atexit.register(DataDog.stop)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 requires = ['six', 'requests', 'datadog']
-tests_requires = ['pytest', 'pytest-cache', 'pytest-cov']
+tests_requires = ['pytest', 'pytest-cache', 'pytest-cov', 'mock']
 
 
 # Mock is part of Python 3 so we only need it in Python 2.x

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ class PyTest(TestCommand):
 
 setup(
     name='python-panopticon',
-    version='0.1.1',
+    version='0.2.0',
     description='A collection of healthcheck and monitoring helpers.',
     long_description='\n\n'.join([open('README.rst').read()]),
     license=open('LICENSE').read(),

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -96,7 +96,7 @@ def test_metrics(method_name):
 
     dd_method(metric_name, value, tags=tags)
 
-    mocked_method.assert_called_once()
+    assert mocked_method.call_count == 1
     mocked_method.assert_called_with(
         metric_prefix + '.' + metric_name,
         value=value,

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
+import collections
+
 from panopticon.compat import mock
 
 from panopticon.datadog import DataDog
@@ -22,7 +24,7 @@ def test_track_time():
 
     with mock.patch('panopticon.datadog.time.time') as time:
         time.side_effect = [1, 2]
-        histogram = DataDog.stats().histogram = mock.Mock()
+        DataDog.stats().histogram = mock.Mock()
 
         @DataDog.track_time('track_time_test')
         def test_function():
@@ -42,3 +44,55 @@ def test_api_key():
     configured_api_key = DataDog.settings[DataDog.KEY_DATADOG_API_KEY]
 
     assert configured_api_key == 'test_api_key'
+
+
+def test_metrics():
+    metric_prefix = test_metrics.__name__
+    DataDog.configure_settings({'DATADOG_STATS_ENABLED': True,
+                                'DATADOG_STATS_PREFIX': metric_prefix})
+
+    mock_dd = DataDog.stats()
+    for method in ['gauge', 'increment', 'decrement', 'histogram', 'event']:
+        setattr(mock_dd, method, mock.Mock())
+
+    DataDog.gauge('abc', 2, tags={'xyz1': 123})
+    mock_dd.gauge.assert_called_with(
+        metric_prefix + '.abc',
+        value=2,
+        tags=['xyz1:123']
+    )
+
+    DataDog.increment('def.fed', 3, tags={'xyz2': 456})
+    mock_dd.increment.assert_called_with(
+        metric_prefix + '.def.fed',
+        value=3,
+        tags=['xyz2:456']
+    )
+
+    DataDog.decrement('', 4, tags={'xyz3': 'ping'})
+    mock_dd.decrement.assert_called_with(
+        metric_prefix + '.',
+        value=4,
+        tags=['xyz3:ping']
+    )
+
+    DataDog.histogram('jkl', 1.23, tags={'xyz4': 4.56})
+    mock_dd.histogram.assert_called_with(
+        metric_prefix + '.jkl',
+        value=1.23,
+        tags=['xyz4:4.56']
+    )
+
+    tags = collections.OrderedDict(
+        [
+            ('xyz5', 567),
+            ('abc2', 'pqr')
+        ]
+    )
+
+    DataDog.event('mno', 'This is the text', tags=tags)
+    mock_dd.event.assert_called_with(
+        'mno',
+        'This is the text',
+        tags=['xyz5:567', 'abc2:pqr']
+    )


### PR DESCRIPTION
- Add `gauge`, `increment`, `decrement`, `histogram` and `event` as class methods on the `DataDog` object, allowing tags to be passed as a dict, and with comments on method usage.
- Add tests
- Bump version
