### PR TITLE
Ensure tags in internal calls are sorted when using mocks

### DIFF
--- a/panopticon/datadog.py
+++ b/panopticon/datadog.py
@@ -196,8 +196,7 @@ class DataDog(object):
         the DataDog format of a list of 'key:value' strings.
 
         To make it easier to write test assertions that validate
-        mock calls, if the stats object has been mocked, the
-        resulting list is sorted.
+        mock calls, the resulting list is sorted.
 
         Args:
             tags (Dict, Sequence):
@@ -213,10 +212,7 @@ class DataDog(object):
         else:
             result = list(tags)
 
-        if isinstance(cls._stats_instance, mock.Mock):
-            return sorted(result)
-
-        return result
+        return sorted(result)
 
     @classmethod
     def gauge(cls, metric_name, value, tags=None, **kwargs):

--- a/panopticon/datadog.py
+++ b/panopticon/datadog.py
@@ -189,11 +189,15 @@ class DataDog(object):
 
         return track_time_decorator
 
-    @staticmethod
-    def _convert_tags(tags):
+    @classmethod
+    def _convert_tags(cls, tags):
         """
         Convert tags, which may be a dict or iterable, into
         the DataDog format of a list of 'key:value' strings.
+
+        To make it easier to write test assertions that validate
+        mock calls, if the stats object has been mocked, the
+        resulting list is sorted.
 
         Args:
             tags (Dict, Sequence):
@@ -202,12 +206,17 @@ class DataDog(object):
             [str]
         """
         if isinstance(tags, dict):
-            return [
+            result = [
                 '{}:{}'.format(key, value)
                 for key, value in tags.items()
             ]
+        else:
+            result = list(tags)
 
-        return list(tags)
+        if isinstance(cls._stats_instance, mock.Mock):
+            return sorted(result)
+
+        return result
 
     @classmethod
     def gauge(cls, metric_name, value, tags=None, **kwargs):

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -102,7 +102,7 @@ def test_metrics(method_name):
         value=value,
         tags=sorted(
             [
-                key + ':' + value
+                '{}:{}'.format(key, value)
                 for key, value in tags.items()
             ]
         )

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -100,10 +100,12 @@ def test_metrics(method_name):
     mocked_method.assert_called_with(
         metric_prefix + '.' + metric_name,
         value=value,
-        tags=[
-            key + ':' + value
-            for key, value in tags.items()
-        ]
+        tags=sorted(
+            [
+                key + ':' + value
+                for key, value in tags.items()
+            ]
+        )
     )
 
 
@@ -127,5 +129,5 @@ def test_event():
     mock_dd.event.assert_called_with(
         'mno',
         'This is the text',
-        tags=['xyz5:567', 'abc2:pqr']
+        tags=['abc2:pqr', 'xyz5:567']
     )


### PR DESCRIPTION
Ensure tags in internal calls are sorted when using mocks.

It's difficult to write assertions (`mock.assert_called_with`) for the mocked methods of the `stats()` object using the DataDog package, since there is no guarantee of the order of any tags supplied
to the call. This change sorts the list before passing it, in the case where `cls._stats_instance` is a `Mock`, so that assertions can rely on the value of tag lists.

Status: **Opened for review**

Reviewers: *\* @elbaschid  **
## Changes
- Add sorting in `_convert_tags`
- Sort test values
