### PR TITLE
Healthchecks for Humans 💁 > 🤖

### DIFF
--- a/panopticon/django/views.py
+++ b/panopticon/django/views.py
@@ -1,14 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 from rest_framework import status
-from rest_framework.views import APIView
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from ..health import HealthCheck
 
 
+class PrettyJsonRenderer(JSONRenderer):
+    def get_indent(self, accepted_media_type, renderer_context):
+        return 2
+
+
 class HealthCheckView(APIView):
     permission_classes = []
+    renderer_classes = (PrettyJsonRenderer, )
 
     def get(self, request, *args, **kwargs):
         health_check = HealthCheck()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-requires = ['six', 'requests', 'datadog']
+requires = ['six', 'requests', 'datadog', 'structlog', 'djangorestframework']
 tests_requires = ['pytest', 'pytest-cache', 'pytest-cov', 'mock']
 
 
@@ -13,7 +13,7 @@ if sys.version_info < (3,):
     tests_requires.append('mock')
 
 
-dev_requires = ['tox', 'bumpversion', 'twine', 'wheel']
+dev_requires = ['tox', 'bumpversion', 'twine', 'wheel', 'django']
 
 
 class PyTest(TestCommand):

--- a/tests/django/test_views.py
+++ b/tests/django/test_views.py
@@ -1,0 +1,22 @@
+import httplib
+
+import django
+from django.conf import settings
+from django.test import SimpleTestCase
+
+
+settings.configure(DEBUG=True,
+                   ROOT_URLCONF='urls',
+                   # `auth` and `contenttypes` to stop `rest_framework` from blowing up.
+                   INSTALLED_APPS=['django.contrib.auth',
+                                   'django.contrib.contenttypes',
+                                   'panopticon.django'],
+                   MIDDLEWARE_CLASSES=[])
+
+django.setup()
+
+
+class TestHealthCheckView(SimpleTestCase):
+    def test(self):
+        response = self.client.get('/healthcheck/')
+        self.assertEqual(response.status_code, httplib.OK)

--- a/tests/django/urls.py
+++ b/tests/django/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url, include
+
+
+urlpatterns = [
+    url(r'', include('panopticon.django.urls', namespace='panopticon')),
+]


### PR DESCRIPTION
By default Django REST framework optimizes its responses for machines:

http://www.django-rest-framework.org/api-guide/renderers/#jsonrenderer

I'm tired of getting out my 👓 to try to read a healthcheck response when I open it up in a browser. 

This change makes the default response human readable and also adds a bunch of the required machinery to test that it works.
